### PR TITLE
Deprecate 'localIdentifierShort'

### DIFF
--- a/assets/js/map.js
+++ b/assets/js/map.js
@@ -67,7 +67,7 @@ var drawMap = function () {
             $(data).each(function (i, row) {
               var result = {
                 fullName: row[0].preferredName + ' ' + row[0].lastName,
-                localIdentifierShort: row[0].localIdentifierShort,
+                localIdentifier: row[0].localIdentifier,
                 distance: row.distance,
                 classYear: row[0].classYear ? ' (' + row[0].classYear + ')' : '',
                 status: row[0].status.label,
@@ -76,7 +76,7 @@ var drawMap = function () {
                 tags: formatTags(row[0])
               }
               searchResultsContainer.append(L.Util.template(
-                '<div><strong><a href="{link}" target="_blank">{fullName}</a> {classYear}</strong>{tags}<br />{localIdentifierShort} / {status}</div><hr />', result
+                '<div><strong><a href="{link}" target="_blank">{fullName}</a> {classYear}</strong>{tags}<br />{localIdentifier} / {status}</div><hr />', result
               ))
             })
           }
@@ -110,14 +110,14 @@ var formatMemberData = function (data) {
 
 var formatMemberPopup = function (data) {
   return L.Util.template(
-    '<strong><a href="{link}">{preferredName} {lastName}</a> {classYear}</strong>{tags}<br />{localIdentifierShort} / {statusLabel}<hr />{mailingAddressLine1} {mailingAddressLine2}<br />{mailingCity}, {mailingState} {mailingPostalCode}',
+    '<strong><a href="{link}">{preferredName} {lastName}</a> {classYear}</strong>{tags}<br />{localIdentifier} / {statusLabel}<hr />{mailingAddressLine1} {mailingAddressLine2}<br />{mailingCity}, {mailingState} {mailingPostalCode}',
     data
   )
 }
 
 var formatMemberTooltip = function (data) {
   return L.Util.template(
-    '<strong>{preferredName} {lastName} {classYear}</strong>{tags}<br />{localIdentifierShort} / {statusLabel}',
+    '<strong>{preferredName} {lastName} {classYear}</strong>{tags}<br />{localIdentifier} / {statusLabel}',
     data
   )
 }

--- a/src/Entity/Member.php
+++ b/src/Entity/Member.php
@@ -672,13 +672,6 @@ class Member
         return sprintf('%s, %s (%s)', $this->lastName, $this->preferredName, $this->localIdentifier);
     }
 
-    public function getLocalIdentifierShort(): string
-    {
-        // <Chapter Identifier>-<Roll Number>
-        preg_match('/^(\d+)\-(\d+)$/', $this->localIdentifier, $matches);
-        return isset($matches[2]) ? ltrim((string) $matches[2], '0') : 'N/A';
-    }
-
     public function getDisplayName(): string
     {
         return $this->preferredName . ' ' . $this->lastName;

--- a/src/Service/EmailService.php
+++ b/src/Service/EmailService.php
@@ -170,10 +170,6 @@ class EmailService
                 'Value' => $member->getLocalIdentifier()
             ],
             [
-                'Key' => 'Local Identifier Short',
-                'Value' => $member->getLocalIdentifierShort()
-            ],
-            [
                 'Key' => 'External Identifier',
                 'Value' => $member->getExternalIdentifier()
             ],

--- a/src/Service/MemberToCsvService.php
+++ b/src/Service/MemberToCsvService.php
@@ -15,7 +15,6 @@ class MemberToCsvService
         $csvWriter->insertOne([
             'externalIdentifier',
             'localIdentifier',
-            'localIdentifierShort',
             'status',
             'firstName',
             'preferredName',
@@ -51,7 +50,6 @@ class MemberToCsvService
         return [
             $member->getExternalIdentifier(),
             $member->getLocalIdentifier(),
-            $member->getLocalIdentifierShort(),
             $member->getStatus(),
             $member->getFirstName(),
             $member->getPreferredName(),

--- a/templates/directory/_row.html.twig
+++ b/templates/directory/_row.html.twig
@@ -1,5 +1,5 @@
 <tr class="{% if member.status.isInactive %}inactive{% endif %}">
-  <td class="text-center" data-order="{{ member.localIdentifier }}">{{ member.localIdentifierShort }}</td>
+  <td class="text-center" data-order="{{ member.localIdentifier }}">{{ member.localIdentifier }}</td>
   <td class="col-profile-img">
     <a href="{{ path('member_show', {localIdentifier: member.localIdentifier}) }}">
       <img src="{{ member.photoUrl ? member.photoUrl : gravatar(member.primaryEmail) }}" class="img-fluid img-profile-sm" alt="Profile Photo" />

--- a/templates/directory/recent_changes.html.twig
+++ b/templates/directory/recent_changes.html.twig
@@ -41,7 +41,7 @@
             <td class="text-muted small" nowrap>
               {{ member.updatedAt|date('n/j/Y h:i a') }}
             </td>
-            <td class="text-center">{{ member.localIdentifierShort }}</td>
+            <td class="text-center">{{ member.localIdentifier }}</td>
             <td width="32">
               <a href="{{ path('member_show', {localIdentifier: member.localIdentifier}) }}">
                 <img src="{{ member.photoUrl ? member.photoUrl : gravatar(member.primaryEmail) }}" class="img-fluid img-profile-sm" alt="Profile Photo" />

--- a/templates/member/show.html.twig
+++ b/templates/member/show.html.twig
@@ -43,7 +43,7 @@
               </tr>
               <tr>
                 <th>Roll #</th>
-                <td>{{ member.localIdentifierShort }}</td>
+                <td>{{ member.localIdentifier }}</td>
               </tr>
               <tr>
                 <th>Join Date</th>


### PR DESCRIPTION
As we continue to make the application more general purpose, the `<chapter>-<member>` format for the *Role #* column was confusing. Will require updates in the custom fields (and templates) in Campaign Monitor.