### PR TITLE
Remove Facebook user images

### DIFF
--- a/src/Command/EspAuditCommand.php
+++ b/src/Command/EspAuditCommand.php
@@ -41,7 +41,7 @@ class EspAuditCommand extends Command
 
         if (!$this->emailService->isConfigured()) {
             $io->error('Email service not configured.');
-            return 1;
+            return Command::FAILURE;
         }
 
         $members = $this->entityManager->getRepository(Member::class)->findByActiveMemberStatuses();
@@ -91,6 +91,6 @@ class EspAuditCommand extends Command
 
         $io->success('Done!');
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Command/EspSyncCommand.php
+++ b/src/Command/EspSyncCommand.php
@@ -97,6 +97,6 @@ class EspSyncCommand extends Command
         $io->writeln(implode(PHP_EOL, $output['ignored']));
 
         $io->success('Done!');
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Command/MemberGeocodeCommand.php
+++ b/src/Command/MemberGeocodeCommand.php
@@ -51,7 +51,7 @@ class MemberGeocodeCommand extends Command
         ]);
         if (is_null($member)) {
             $io->error('Member not found matching Local Identifier: ' . $localIdentifier);
-            return 1;
+            return Command::FAILURE;
         }
 
         // Clear existing coordinates
@@ -71,7 +71,7 @@ class MemberGeocodeCommand extends Command
             $io->writeln('<options=bold>Longitude:</>       ' . $member->getMailingLongitude());
         } catch (\Exception $e) {
             $io->error($e->getMessage());
-            return 1;
+            return Command::FAILURE;
         }
 
         if ($input->getOption('save')) {
@@ -80,6 +80,6 @@ class MemberGeocodeCommand extends Command
         }
 
         $io->success('Done!');
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Command/RemoveFbImagesCommand.php
+++ b/src/Command/RemoveFbImagesCommand.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Command;
+
+use App\Repository\MemberRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class RemoveFbImagesCommand extends Command
+{
+    protected static $defaultName = 'app:remove-fb-images';
+    protected $memberRepository;
+    protected $em;
+
+    public function __construct(MemberRepository $memberRepository, EntityManagerInterface $entityManager)
+    {
+        parent::__construct();
+        $this->memberRepository = $memberRepository;
+        $this->em = $entityManager;
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setDescription('Removes legacy Facebook images from Member records.')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $result = $this->memberRepository->createQueryBuilder('m')
+            ->where('m.photoUrl LIKE :facebookImage')
+            ->setParameter('facebookImage', 'https://graph.facebook.com/%')
+            ->getQuery()
+            ->getResult();
+
+        foreach ($result as $i => $member) {
+            $io->writeln(sprintf('Updating %s ...', $member));
+            $member->setPhotoUrl(null);
+            $this->em->persist($member);
+
+            if ($i%50) {
+                $this->em->flush();
+            }
+            $this->em->flush();
+        }
+
+        $io->success(sprintf('Done! (%d records updated)', count($result)));
+        return Command::SUCCESS;
+    }
+}

--- a/src/Command/UserAddCommand.php
+++ b/src/Command/UserAddCommand.php
@@ -62,7 +62,7 @@ class UserAddCommand extends Command
 
         if (!$password || $password != $password_confirm) {
             $io->error('Passwords did not match, or were blank.');
-            return 1;
+            return Command::FAILURE;
         }
 
         // Add user to the database
@@ -77,6 +77,6 @@ class UserAddCommand extends Command
         $this->entityManager->flush();
 
         $io->success(sprintf('You have added %s to the system as ID %d.', $user->getEmail(), $user->getId()));
-        return 0;
+        return Command::SUCCESS;
     }
 }


### PR DESCRIPTION
Add a console command to remove Facebook images from the `photoUrl` property of members as we can no longer load those in without an access token.

```bash
$ bin/console app:remove-fb-images
```

From https://developers.facebook.com/docs/graph-api/changelog/non-versioned-changes/oct-24-2020/

> #### User Picture
>
>    `GET /user/picture` now requires an access token if querying a User ID (UID). Querying an App-Scoped User ID still does not require an access token.