### PR TITLE
Address various data validation and cross-site scripting vulnerabilities

### DIFF
--- a/assets/js/directory.js
+++ b/assets/js/directory.js
@@ -3,6 +3,13 @@
 
 var gravatar = require('gravatar');
 
+var sanitizeHTML = function (str) {
+  if (!str) { return ''; }
+	return str.replace(/[^\w. ]/gi, function (c) {
+		return '&#' + c.charCodeAt(0) + ';';
+	});
+};
+
 $(document).ready(function() {
   var memberDataTable = $('#memberDataTable').DataTable({
     serverSide: true,
@@ -59,7 +66,7 @@ $(document).ready(function() {
         className: "col-img-profile text-center",
         render: function (data, type, row, meta) {
           var link = Routing.generate('member_show', {localIdentifier: row.localIdentifier});
-          var photoUrl = data;
+          var photoUrl = sanitizeHTML(data);
           if (!photoUrl) {
             photoUrl = gravatar.url(row.primaryEmail, {default: 'mm'});
           }
@@ -73,7 +80,7 @@ $(document).ready(function() {
         data: "displayName",
         render: function (data, type, row, meta) {
           var link = Routing.generate('member_show', {localIdentifier: row.localIdentifier});
-          var output = '<a href="' + link + '">' + data + '</a><div class="mt-1">';
+          var output = '<a href="' + link + '">' + sanitizeHTML(data) + '</a><div class="mt-1">';
           // Deceased
           if (row.isDeceased) {
             var deceasedLink = Routing.generate('deceased');
@@ -93,7 +100,7 @@ $(document).ready(function() {
           if (row.tags) {
             for (var i in row.tags) {
               var tagLink = Routing.generate('tag', {tagId: row.tags[i].id});
-              output += '<a href="' + tagLink + '"><sup class="badge badge-secondary" title="' + row.tags[i].tagName + '">' + row.tags[i].tagName + '</sup></a> ';
+              output += '<a href="' + tagLink + '"><sup class="badge badge-secondary" title="' + sanitizeHTML(row.tags[i].tagName) + '">' + sanitizeHTML(row.tags[i].tagName) + '</sup></a> ';
             }
           }
           output += '</div>';
@@ -147,14 +154,14 @@ $(document).ready(function() {
             return output;
           }
           if (row.mailingAddressLine1) {
-            output += row.mailingAddressLine1 + '<br />';
+            output += sanitizeHTML(row.mailingAddressLine1) + '<br />';
           }
           if (row.mailingAddressLine2) {
-            output += row.mailingAddressLine2 + '<br />';
+            output += sanitizeHTML(row.mailingAddressLine2) + '<br />';
           }
-          output += row.mailingCity + ', ' + row.mailingState + ' ' + row.mailingPostalCode + '<br />';
+          output += sanitizeHTML(row.mailingCity) + ', ' + sanitizeHTML(row.mailingState) + ' ' + sanitizeHTML(row.mailingPostalCode) + '<br />';
           if (row.mailingCountry != 'United States' && row.mailingCountry != 'US') {
-            output += row.mailingCountry;
+            output += sanitizeHTML(row.mailingCountry);
           }
           return output;
         }
@@ -162,6 +169,12 @@ $(document).ready(function() {
       {
         data: "mailingState",
         visible: false
+      }
+    ],
+    columnDefs: [
+      {
+        targets: '_all',
+        render: $.fn.dataTable.render.text()
       }
     ]
   });

--- a/src/Controller/MemberController.php
+++ b/src/Controller/MemberController.php
@@ -71,6 +71,7 @@ class MemberController extends AbstractController
      */
     public function memberEdit(Member $member, Request $request): Response
     {
+        $originalMember = clone $member;
         $form = $this->createForm(MemberType::class, $member);
         $form->handleRequest($request);
         if ($form->isSubmitted() && $form->isValid()) {
@@ -83,7 +84,7 @@ class MemberController extends AbstractController
             ]));
         }
         return $this->render('member/edit.html.twig', [
-            'member' => $member,
+            'member' => $originalMember,
             'form' => $form->createView()
         ]);
     }

--- a/src/Entity/Member.php
+++ b/src/Entity/Member.php
@@ -20,7 +20,9 @@ use Symfony\Component\Validator\Constraints as Assert;
  *   }
  * )
  * @ORM\HasLifecycleCallbacks
- * @UniqueEntity({"localIdentifier","externalIdentifier"})
+ * @UniqueEntity("localIdentifier")
+ * @UniqueEntity("externalIdentifier")
+ * @UniqueEntity("primaryEmail")
  * @Gedmo\Loggable
  */
 class Member
@@ -42,6 +44,12 @@ class Member
     /**
      * @ORM\Column(type="string", nullable=true, length=255, unique=true)
      * @Assert\NotBlank
+     * @Assert\Regex(
+     *     pattern     = "/^[a-z0-9\-\_]+$/i",
+     *     htmlPattern = "[a-zA-Z0-9\-\_]+",
+     *     match       = true,
+     *     message     = "Only alphanumeric characters, dashes and underscores are allowed."
+     * )
      * @Gedmo\Versioned
      * @Groups({"member_main"})
      */
@@ -50,6 +58,12 @@ class Member
     /**
      * @ORM\Column(type="string", nullable=true, length=255, unique=true)
      * @Assert\NotBlank
+     * @Assert\Regex(
+     *     pattern     = "/^[a-z0-9\-\_]+$/i",
+     *     htmlPattern = "[a-zA-Z0-9\-\_]+",
+     *     match       = true,
+     *     message     = "Only alphanumeric characters, dashes and underscores are allowed."
+     * )
      * @Gedmo\Versioned
      * @Groups({"member_extended"})
      */

--- a/templates/_alerts.html.twig
+++ b/templates/_alerts.html.twig
@@ -3,7 +3,7 @@
     {% for message in messages %}
         {%if type == 'error'%} {% set type = 'danger' %} {%endif%}
         <div class="alert alert-{{ type }} alert-dismissable fade show" role="alert">
-            {{ message|raw }}
+            {{ message }}
             <button type="button" class="close" data-dismiss="alert" aria-label="Close">
               <span aria-hidden="true">&times;</span>
             </button>

--- a/templates/communication/_row.html.twig
+++ b/templates/communication/_row.html.twig
@@ -7,7 +7,7 @@
   <td data-order="{{ log.type }}">
     {{ macros.typeIcon(log) }}
   </td>
-  <td>{{ log.summary|u.truncate(200, '...', false)|markdown_to_html }}</td>
+  <td>{{ log.summary|u.truncate(200, '...', false)|e('html')|markdown_to_html }}</td>
   <td>{{ log.user|default('System') }}</td>
   <td><a href="{{ path('communication_edit', {id: log.id }) }}"><i class="fas fa-edit"></i></a></td>
 </tr>

--- a/templates/communication/show.html.twig
+++ b/templates/communication/show.html.twig
@@ -22,7 +22,7 @@
       <dt class="col-sm-2 mb-3">User</dt>
       <dd class="col-sm-10 mb-3">{{ communication_log.user|default('System') }}</dd>
       <dt class="col-sm-2 mb-3">Summary</dt>
-      <dd class="col-sm-10 mb-3">{{ communication_log.summary|markdown_to_html }}</d>
+      <dd class="col-sm-10 mb-3">{{ communication_log.summary|e('html')|markdown_to_html }}</d>
     </dl>
   </div>
 </div>

--- a/templates/directory/message_email_template.html.twig
+++ b/templates/directory/message_email_template.html.twig
@@ -5,7 +5,7 @@
     <title>{{ subject }}</title>
   </head>
   <body style="font-family:sans-serif; font-size:10pt;">
-    {{ body|markdown_to_html }}
+    {{ body|e('html')|markdown_to_html }}
 
   </body>
 </html>

--- a/templates/member/show.html.twig
+++ b/templates/member/show.html.twig
@@ -81,7 +81,7 @@
               <dl class="row">
                 <dt class="col-sm-3 mb-3">Directory Notes</dt>
                 <dd class="col-sm-9 mb-3">
-                  {{ member.directoryNotes|markdown_to_html }}
+                  {{ member.directoryNotes|e('html')|markdown_to_html }}
                 </dd>
               </dl>
               {% endif %}


### PR DESCRIPTION
**Thanks to @dvb004 (working through @huntr-helper) with for finding these and writing up the report.**

- Remove `|raw` Twig filter in the Alerts template (caused most of the reports)
- Set a few parameters around what is a valid localIdentifier
- Clean up `directory.js` to sanitize values before rendering
- Run `|e('html')` before rendering Markdown fields

---

Fixes #238
Fixes #239
Fixes #240
Fixes #241