### PR TITLE
Autopopulate messenger recipients

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -5,6 +5,7 @@
  * you can change this configuration by importing this file.
  */
 $config = new PhpCsFixer\Config();
+
 return $config
     ->setRules([
         '@DoctrineAnnotation' => true,
@@ -14,7 +15,7 @@ return $config
         '@Symfony' => true,
     ])
     ->setFinder(PhpCsFixer\Finder::create()
-        ->exclude(['vendor', 'cache'])
+        ->exclude(['vendor', 'cache', 'node_modules'])
         ->in(__DIR__)
     )
 ;

--- a/src/Controller/DirectoryController.php
+++ b/src/Controller/DirectoryController.php
@@ -265,6 +265,10 @@ class DirectoryController extends AbstractController
                 'view_name' => $tag->getTagName(),
                 'show_status' => true,
                 'data_source' => $this->generateUrl('tag', ['tagId' => $tagId, '_format' => 'json']),
+                'messenger' => [
+                    'key' => 'tag_id',
+                    'value' => $tag->getId(),
+                ],
             ]);
         }
         $members = $memberRepository->findByTags([$tag], [

--- a/src/Controller/MemberController.php
+++ b/src/Controller/MemberController.php
@@ -397,7 +397,7 @@ class MemberController extends AbstractController
             }
         }
 
-        $formSMS = $this->createForm(MemberSMSType::class, null, ['acting_user' => $this->getUser()]);
+        $formSMS = $this->createForm(MemberSMSType::class, null, ['member' => $member, 'acting_user' => $this->getUser()]);
         $formSMS->handleRequest($request);
         if ($formSMS->isSubmitted() && $formSMS->isValid()) {
             if (!$member->getPrimaryTelephoneNumber()) {

--- a/src/Controller/MessengerController.php
+++ b/src/Controller/MessengerController.php
@@ -2,6 +2,7 @@
 
 namespace App\Controller;
 
+use App\Entity\Member;
 use App\Form\MemberEmailType;
 use App\Form\MemberSMSType;
 use App\Service\CommunicationLogService;
@@ -32,7 +33,12 @@ class MessengerController extends AbstractController
      */
     public function email(Request $request, EmailService $emailService, CommunicationLogService $communicationLogService): Response
     {
-        $formEmail = $this->createForm(MemberEmailType::class, null, ['acting_user' => $this->getUser()]);
+        $queryRecipients = $this->buildRecipientsFromRequest($request);
+
+        $formEmail = $this->createForm(MemberEmailType::class, null, [
+            'acting_user' => $this->getUser(),
+            'recipients' => $queryRecipients,
+        ]);
         $formEmail->handleRequest($request);
         if ($formEmail->isSubmitted() && $formEmail->isValid()) {
             $formData = $formEmail->getData();
@@ -69,7 +75,12 @@ class MessengerController extends AbstractController
      */
     public function sms(Request $request, SmsService $smsService, CommunicationLogService $communicationLogService): Response
     {
-        $formSMS = $this->createForm(MemberSMSType::class, null, ['acting_user' => $this->getUser()]);
+        $queryRecipients = $this->buildRecipientsFromRequest($request);
+
+        $formSMS = $this->createForm(MemberSMSType::class, null, [
+            'acting_user' => $this->getUser(),
+            'recipients' => $queryRecipients,
+        ]);
         $formSMS->handleRequest($request);
         if ($formSMS->isSubmitted() && $formSMS->isValid()) {
             $formData = $formSMS->getData();
@@ -97,4 +108,18 @@ class MessengerController extends AbstractController
             'fromTelephoneNumber' => $smsService->getFromTelephoneNumber(),
         ]);
     }
+
+    private function buildRecipientsFromRequest(Request $request): array
+    {
+        $queryRecipients = [];
+
+        // List of identifiers
+        if (is_array($request->query->get('recipients'))) {
+            $memberRepository = $this->getDoctrine()->getRepository(Member::class);
+            $queryRecipients = $memberRepository->findByLocalIdentifiers($request->query->get('recipients'));
+        }
+
+        return $queryRecipients;
+    }
+
 }

--- a/src/Controller/MessengerController.php
+++ b/src/Controller/MessengerController.php
@@ -116,7 +116,7 @@ class MessengerController extends AbstractController
         $queryRecipients = [];
 
         // List of identifiers
-        if (is_array($request->query->get('recipients'))) {
+        if ($request->query->get('recipients')) {
             $memberRepository = $this->getDoctrine()->getRepository(Member::class);
             $queryRecipients = $memberRepository->findByLocalIdentifiers($request->query->get('recipients'));
         }

--- a/src/Controller/MessengerController.php
+++ b/src/Controller/MessengerController.php
@@ -2,7 +2,9 @@
 
 namespace App\Controller;
 
+use App\Entity\Event;
 use App\Entity\Member;
+use App\Entity\Tag;
 use App\Form\MemberEmailType;
 use App\Form\MemberSMSType;
 use App\Service\CommunicationLogService;
@@ -119,7 +121,22 @@ class MessengerController extends AbstractController
             $queryRecipients = $memberRepository->findByLocalIdentifiers($request->query->get('recipients'));
         }
 
+        // Event attendees
+        if ($request->query->get('event_id')) {
+            $event = $this->getDoctrine()->getRepository(Event::class)->find($request->query->get('event_id'));
+            if ($event) {
+                $queryRecipients = $event->getAttendees()->toArray();
+            }
+        }
+
+        // Tagged Members
+        if ($request->query->get('tag_id')) {
+            $tag = $this->getDoctrine()->getRepository(Tag::class)->find($request->query->get('tag_id'));
+            if ($tag) {
+                $queryRecipients = $tag->getMembers()->toArray();
+            }
+        }
+
         return $queryRecipients;
     }
-
 }

--- a/src/Controller/MessengerController.php
+++ b/src/Controller/MessengerController.php
@@ -114,23 +114,24 @@ class MessengerController extends AbstractController
     private function buildRecipientsFromRequest(Request $request): array
     {
         $queryRecipients = [];
+        $queryParameters = $request->query->all();
 
         // List of identifiers
-        if ($request->query->get('recipients')) {
+        if (isset($queryParameters['recipients']) && is_array($queryParameters['recipients'])) {
             $memberRepository = $this->getDoctrine()->getRepository(Member::class);
-            $queryRecipients = $memberRepository->findByLocalIdentifiers($request->query->get('recipients'));
+            $queryRecipients = $memberRepository->findByLocalIdentifiers($queryParameters['recipients']);
         }
 
         // Event attendees
-        if ($request->query->get('event_id')) {
-            $event = $this->getDoctrine()->getRepository(Event::class)->find($request->query->get('event_id'));
+        if (isset($queryParameters['event_id']) && is_numeric($queryParameters['event_id'])) {
+            $event = $this->getDoctrine()->getRepository(Event::class)->find($queryParameters['event_id']);
             if ($event) {
                 $queryRecipients = $event->getAttendees()->toArray();
             }
         }
 
         // Tagged Members
-        if ($request->query->get('tag_id')) {
+        if (isset($queryParameters['tag_id']) && is_numeric($queryParameters['tag_id'])) {
             $tag = $this->getDoctrine()->getRepository(Tag::class)->find($request->query->get('tag_id'));
             if ($tag) {
                 $queryRecipients = $tag->getMembers()->toArray();

--- a/src/Form/MemberEmailType.php
+++ b/src/Form/MemberEmailType.php
@@ -63,6 +63,7 @@ class MemberEmailType extends AbstractType
                     'title' => 'Search for Member(s) ...',
                 ],
                 'multiple' => true,
+                'data' => $options['recipients'],
             ]);
         }
     }
@@ -72,6 +73,7 @@ class MemberEmailType extends AbstractType
         $resolver->setDefaults([
             'member' => null,
             'acting_user' => null,
+            'recipients' => [],
         ]);
     }
 }

--- a/src/Form/MemberSMSType.php
+++ b/src/Form/MemberSMSType.php
@@ -48,6 +48,7 @@ class MemberSMSType extends AbstractType
                     'title' => 'Search for Member(s) ...',
                 ],
                 'multiple' => true,
+                'data' => $options['recipients'],
             ]);
         }
     }
@@ -57,6 +58,7 @@ class MemberSMSType extends AbstractType
         $resolver->setDefaults([
             'member' => null,
             'acting_user' => null,
+            'recipients' => [],
         ]);
     }
 }

--- a/src/Repository/MemberRepository.php
+++ b/src/Repository/MemberRepository.php
@@ -292,6 +292,16 @@ class MemberRepository extends ServiceEntityRepository
         return new Paginator($qb->getQuery(), $fetchJoinCollection = true);
     }
 
+    public function findByLocalIdentifiers(array $localIdentifiers)
+    {
+        return $this->createQueryBuilder('m')
+            ->where('m.localIdentifier IN (:localIdentifiers)')
+            ->setParameter('localIdentifiers', $localIdentifiers)
+            ->getQuery()
+            ->getResult()
+        ;
+    }
+
     private function processParams(QueryBuilder $qb, $params = []): QueryBuilder
     {
         // Filter by Member Status

--- a/templates/directory/directory.html.twig
+++ b/templates/directory/directory.html.twig
@@ -6,6 +6,17 @@
 {% embed '_page_header.html.twig' %}
 {% block page_header_title %}{{ view_name }}{% endblock %}
 {% block page_header_buttons %}
+{% if messenger is defined and is_granted('ROLE_COMMUNICATIONS_MANAGER') %}
+<button type="button" class="btn btn-secondary btn-sm dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
+  <i class="fas fa-comments fa-fw"></i> Messenger
+</button>
+<div class="dropdown-menu">
+  <a class="dropdown-item" href="{{ path('messenger_email', {(messenger.key) : messenger.value}) }}"><i class="fas fa-envelope fa-fw"></i> Send Email</a>
+  {% if is_sms_service_configured() %}
+  <a class="dropdown-item" href="{{ path('messenger_sms', {(messenger.key) : messenger.value}) }}"><i class="fas fa-sms fa-fw"></i> Send SMS</a>
+  {% endif %}
+</div>
+{% endif %}
 {% if is_granted('ROLE_DIRECTORY_MANAGER') %}
 <a role="button" href="{{ path('member_new') }}" class="btn btn-sm btn-primary"><i class="fas fa-plus fa-fw"></i> New Member</a>
 {% endif %}

--- a/templates/event/show.html.twig
+++ b/templates/event/show.html.twig
@@ -6,6 +6,17 @@
 {% embed '_page_header.html.twig' %}
 {% block page_header_title %}{{ event }}{% endblock %}
 {% block page_header_buttons %}
+{% if is_granted('ROLE_COMMUNICATIONS_MANAGER') %}
+<button type="button" class="btn btn-secondary btn-sm dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
+  <i class="fas fa-comments fa-fw"></i> Messenger
+</button>
+<div class="dropdown-menu">
+  <a class="dropdown-item" href="{{ path('messenger_email', {event_id: event.id}) }}"><i class="fas fa-envelope fa-fw"></i> Send Email</a>
+  {% if is_sms_service_configured() %}
+  <a class="dropdown-item" href="{{ path('messenger_sms', {event_id: event.id}) }}"><i class="fas fa-sms fa-fw"></i> Send SMS</a>
+  {% endif %}
+</div>
+{% endif %}
 <a role="button" href="{{ path('event_ical', {id: event.id}) }}" class="btn btn-secondary btn-sm"><i class="fas fa-calendar-day fa-fw"></i> iCalendar</a>
 <a role="button" href="{{ path('event_edit', {id: event.id}) }}" class="btn btn-primary btn-sm"><i class="fas fa-edit fa-fw"></i> Edit</a>
 {% endblock %}


### PR DESCRIPTION
Adding individual Members in Messenger can be tedious. This provides a pipeline to add them programmatically, as as through matching Events, Tags, etc.