### PR TITLE
Exclude empty phone/email in mass messenger

### DIFF
--- a/src/Form/MemberEmailType.php
+++ b/src/Form/MemberEmailType.php
@@ -49,7 +49,7 @@ class MemberEmailType extends AbstractType
                     return $er->createQueryBuilder('m')
                         ->join('m.status', 's')
                         ->where('s.isInactive = 0')
-                        ->where('m.primaryEmail != :empty')
+                        ->andWhere('m.primaryEmail != :empty')
                         ->setParameter('empty', '')
                         ->addOrderBy('s.label', 'ASC')
                         ->addOrderBy('m.lastName', 'ASC')

--- a/src/Form/MemberEmailType.php
+++ b/src/Form/MemberEmailType.php
@@ -49,6 +49,8 @@ class MemberEmailType extends AbstractType
                     return $er->createQueryBuilder('m')
                         ->join('m.status', 's')
                         ->where('s.isInactive = 0')
+                        ->where('m.primaryEmail != :empty')
+                        ->setParameter('empty', '')
                         ->addOrderBy('s.label', 'ASC')
                         ->addOrderBy('m.lastName', 'ASC')
                         ->addOrderBy('m.preferredName', 'ASC')

--- a/src/Form/MemberSMSType.php
+++ b/src/Form/MemberSMSType.php
@@ -34,6 +34,8 @@ class MemberSMSType extends AbstractType
                     return $er->createQueryBuilder('m')
                         ->join('m.status', 's')
                         ->where('s.isInactive = 0')
+                        ->where('m.primaryTelephoneNumber != :empty')
+                        ->setParameter('empty', '')
                         ->addOrderBy('s.label', 'ASC')
                         ->addOrderBy('m.lastName', 'ASC')
                         ->addOrderBy('m.preferredName', 'ASC')

--- a/src/Form/MemberSMSType.php
+++ b/src/Form/MemberSMSType.php
@@ -34,7 +34,7 @@ class MemberSMSType extends AbstractType
                     return $er->createQueryBuilder('m')
                         ->join('m.status', 's')
                         ->where('s.isInactive = 0')
-                        ->where('m.primaryTelephoneNumber != :empty')
+                        ->andWhere('m.primaryTelephoneNumber != :empty')
                         ->setParameter('empty', '')
                         ->addOrderBy('s.label', 'ASC')
                         ->addOrderBy('m.lastName', 'ASC')

--- a/templates/_modal_hotkeys.html.twig
+++ b/templates/_modal_hotkeys.html.twig
@@ -7,10 +7,10 @@
       </div>
       <div class="modal-body">
         <dl class="row"">
-          <dt class="col-sm-1"><code>?</tt></code>
-          <dd class="col-sm-11">Show this help modal</dt>
-          <dt class="col-sm-1"><code>/</tt></code>
-          <dd class="col-sm-11">Focus on search field</dt>
+          <dt class="col-sm-1"><code>?</code></dt>
+          <dd class="col-sm-11">Show this help modal</dd>
+          <dt class="col-sm-1"><code>/</dt>
+          <dd class="col-sm-11">Focus on search field</dd>
         </dl>
       </div>
     </div>

--- a/tests/Controller/MessengerControllerTest.php
+++ b/tests/Controller/MessengerControllerTest.php
@@ -54,10 +54,13 @@ class MessengerControllerTest extends WebTestCase
         $testUser = $userRepository->findOneByEmail('communications.manager@example.com');
         $client->loginUser($testUser);
 
-        $client->request('GET', '/messenger/email');
+        $crawler = $client->request('GET', '/messenger/email');
         $this->assertResponseIsSuccessful();
         $this->assertPageTitleSame('Member Directory - Messenger - Email');
         $this->assertSelectorTextContains('span.display-6', 'Send Bulk Email');
+        $this->assertStringContainsString('Cox, Lucian (1-0007)', $crawler->filter('#member_email_recipients')->html());
+        $this->assertStringNotContainsString('Wallace, Bill (1-0004)', $crawler->filter('#member_email_recipients')->html());
+        $this->assertStringNotContainsString('(1-0013)', $crawler->filter('#member_email_recipients')->html());
     }
 
     public function testSms()
@@ -67,9 +70,12 @@ class MessengerControllerTest extends WebTestCase
         $testUser = $userRepository->findOneByEmail('communications.manager@example.com');
         $client->loginUser($testUser);
 
-        $client->request('GET', '/messenger/sms');
+        $crawler = $client->request('GET', '/messenger/sms');
         $this->assertResponseIsSuccessful();
         $this->assertPageTitleSame('Member Directory - Messenger - SMS');
         $this->assertSelectorTextContains('span.display-6', 'Send Bulk SMS');
+        $this->assertStringContainsString('Jenkens, Carter (1-0001)', $crawler->filter('#member_sms_recipients')->html());
+        $this->assertStringNotContainsString('Gaw, Ben (1-0002)', $crawler->filter('#member_sms_recipients')->html());
+        $this->assertStringNotContainsString('(1-0013)', $crawler->filter('#member_sms_recipients')->html());
     }
 }


### PR DESCRIPTION
These otherwise appear as errors. Easier to exclude them from the start.
